### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "python main.py"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 A tiny python program to scrap informations from websites. The file `main.py` scraps title, link and author's name from each post of [The NY Times](https://www.nytimes.com/section/technology)' technology section, and saves it in `posts.csv` file.
 
+[![Run on Repl.it](https://repl.it/badge/github/muhfasul159/web-scrapper)](https://repl.it/github/muhfasul159/web-scrapper)
 
 ### Installation
 


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).